### PR TITLE
Remove duplicate flush logic.

### DIFF
--- a/lib/pokerscore/hand.rb
+++ b/lib/pokerscore/hand.rb
@@ -35,20 +35,24 @@ class Hand
     unique_cards.length != 5
   end
 
+  def flush?
+    flush = true
+    cards.each do |card|
+      flush = false if card.suit != cards.first.suit
+    end
+    flush
+  end
 
   private
 
+
   def find_straight(cards)
     sorted = cards.sort_by { |card| card.value }
-    result = { 
-      :range => sorted.first.value..sorted.last.value,
-      :suit => sorted.first.suit
-    }
+    range = (sorted.first.value..sorted.last.value)
     sorted.each_cons(2).each do |card, next_card|
-      result[:range] = nil if not card.value == next_card.value - 1
-      result[:suit] = :mixed if not card.suit == next_card.suit
+      range = nil if not card.value == next_card.value - 1
     end
-    result
+    range
   end
 
   def find_sets(cards)
@@ -62,17 +66,18 @@ class Hand
   end
 
   def find_best_cards(cards)
+    flush = flush?
     best = :high_card
     best = :pair if sets[2].length == 1
     best = :two_pair if sets[2].length == 2
     best = :three_of_a_kind if sets[3].length == 1
-    best = :straight if straight[:range] != nil and straight[:suit] == :mixed
-    best = :flush if cards.each_cons(2).all? { |card, next_card| card.suit == next_card.suit }
+    best = :straight if straight != nil and !flush
+    best = :flush if flush
     best = :full_house if sets[3].length == 1 and sets[2].length == 1
     best = :four_of_a_kind if sets[4].length == 1 
-    if straight[:suit] != :mixed
-      best = :straight_flush if straight[:range] != nil
-      best = :royal_flush if straight[:range] == (10..14)
+    if flush
+      best = :straight_flush if straight != nil
+      best = :royal_flush if straight == (10..14)
     end
     return best
   end

--- a/tests/test_hand.rb
+++ b/tests/test_hand.rb
@@ -48,34 +48,45 @@ class TestHand < Minitest::Test
     end
   end
 
-  def test_hand_can_recognize_mixed_suit_non_straight_cards
+  def test_hand_sets_straight_to_nil_if_does_not_contain_straight
     hand = Hand.new(VALID_CARDS)
-    assert_nil hand.straight[:range]
-    assert_equal hand.straight[:suit], :mixed
+    assert_nil hand.straight
   end
 
-  def test_hand_can_recognize_mixed_suit_straight_cards
-    mixed_straight = [
+  def test_hand_sets_straight_to_proper_range_if_contains_straight
+    straight = [
       Card.new(3, :heart),
       Card.new(4, :spade),
       Card.new(5, :club),
       Card.new(6, :diamond),
       Card.new(7, :heart)
     ]
-    hand = Hand.new(mixed_straight)
-    assert_equal hand.straight[:suit], :mixed
+    hand = Hand.new(straight)
+    assert_equal hand.straight, (3..7)
   end
     
-  def test_hand_can_recognize_same_suit_straight_cards
-    heart_straight = [
+  def test_hand_flush_defaults_to_nil
+    no_flush = [
+      Card.new(3, :heart),
+      Card.new(4, :spade),
+      Card.new(9, :club),
+      Card.new(6, :diamond),
+      Card.new(7, :heart)
+    ]
+    hand = Hand.new(no_flush)
+    assert_equal hand.flush?, false
+  end
+
+  def test_hand_flush_is_true_if_hand_contains_flush
+    flush = [
       Card.new(3, :heart),
       Card.new(4, :heart),
-      Card.new(5, :heart),
+      Card.new(9, :heart),
       Card.new(6, :heart),
       Card.new(7, :heart)
     ]
-    hand = Hand.new(heart_straight)
-    assert_equal hand.straight[:suit], :heart
+    hand = Hand.new(flush)
+    assert_equal hand.flush?, true
   end
 
   def test_hand_can_recognize_a_pair


### PR DESCRIPTION
Previously flushes were checked at the same time as straights, and again
when finding a hand's best cards. Moving that logic into it's own
function means methods in the hand class have singular purposes, and
flushes are only looked for once.