### PR TITLE
Separate identification logic

### DIFF
--- a/lib/pokerscore/hand.rb
+++ b/lib/pokerscore/hand.rb
@@ -3,46 +3,22 @@ require 'lib/pokerscore/set.rb'
 
 class Hand
   attr_reader :cards
-  WHEEL_STRAIGHT = [2,3,4,5,14]
 
   def initialize(cards)
     raise ArgumentError if invalid_hand?(cards)
     @cards = cards
   end
 
-  def sets
-    sets = []
-    unique_values = cards.map(&:value).uniq
-    unique_values.each do |unique_value|
-      occurrances = cards.count { |card| card.value == unique_value }
-      sets << Set.new(unique_value, occurrances)
-    end
-    sets
-  end
-
   def max_value
     cards.max { |card1, card2| card1.value <=> card2.value }.value
   end
 
-  def straight?
-    sorted_values = cards.map(&:value).sort
-    return true if sorted_values == WHEEL_STRAIGHT
-    sorted_values.each_cons(2).each do |value, next_value|
-      return false if not value == next_value - 1
-    end
-    true
+  def to_s
+    cards.map(&:to_s).join(", ")
   end
 
   def invalid_hand?(cards)
     unique_cards = cards.uniq {|card| [card.suit, card.value]}
     unique_cards.length != 5
-  end
-
-  def flush?
-    cards.map(&:suit).uniq.length == 1
-  end
-
-  def to_s
-    cards.map(&:to_s).join(", ")
   end
 end

--- a/lib/pokerscore/hand_evaluator.rb
+++ b/lib/pokerscore/hand_evaluator.rb
@@ -1,3 +1,7 @@
+require 'lib/pokerscore/identify_straight'
+require 'lib/pokerscore/identify_flush'
+require 'lib/pokerscore/identify_sets'
+
 module HandEvaluator
 
   def self.winner(hand1, hand2)
@@ -10,21 +14,23 @@ module HandEvaluator
   end
 
   def self.identify(hand)
-    num_pairs = hand.sets.count { |set| set.pair? }
-    num_trips = hand.sets.count { |set| set.trip? }
-    num_quads = hand.sets.count { |set| set.quad? }
+    num_pairs = IdentifySets.sets(hand).count { |set| set.pair? }
+    num_trips = IdentifySets.sets(hand).count { |set| set.trip? }
+    num_quads = IdentifySets.sets(hand).count { |set| set.quad? }
+    straight = IdentifyStraight.straight?(hand)
+    flush = IdentifyFlush.flush?(hand)
 
     best = :high_card
     best = :pair if num_pairs == 1
     best = :two_pair if num_pairs == 2
     best = :three_of_a_kind if num_trips == 1
-    best = :straight if hand.straight? and !hand.flush?
-    best = :flush if hand.flush?
+    best = :straight if straight and !flush
+    best = :flush if flush
     best = :full_house if num_trips == 1 and num_pairs == 1
-    best = :four_of_a_kind if num_quads == 1 
-    if hand.flush?
-      best = :straight_flush if hand.straight?
-      best = :royal_flush if hand.straight? and hand.max_value == 14
+    best = :four_of_a_kind if num_quads == 1
+    if flush
+      best = :straight_flush if straight
+      best = :royal_flush if straight and hand.max_value == 14
     end
     best
   end
@@ -37,7 +43,7 @@ module HandEvaluator
       hand1
     when 0
       nil
-    when -1 
+    when -1
       hand2
     end
   end
@@ -75,10 +81,10 @@ module HandEvaluator
   end
 
   def self.set_values_in_rank_order(hand)
-    quads = hand.sets.select(&:quad?).map(&:value).sort
-    trips = hand.sets.select(&:trip?).map(&:value).sort
-    pairs = hand.sets.select(&:pair?).map(&:value).sort
-    singles = hand.sets.select(&:single?).map(&:value).sort
+    quads = IdentifySets.sets(hand).select(&:quad?).map(&:value).sort
+    trips = IdentifySets.sets(hand).select(&:trip?).map(&:value).sort
+    pairs = IdentifySets.sets(hand).select(&:pair?).map(&:value).sort
+    singles = IdentifySets.sets(hand).select(&:single?).map(&:value).sort
     quads + trips + pairs + singles
   end
 end

--- a/lib/pokerscore/identify_flush.rb
+++ b/lib/pokerscore/identify_flush.rb
@@ -1,0 +1,5 @@
+module IdentifyFlush
+  def self.flush?(hand)
+    hand.cards.map(&:suit).uniq.length == 1
+  end
+end

--- a/lib/pokerscore/identify_sets.rb
+++ b/lib/pokerscore/identify_sets.rb
@@ -1,0 +1,11 @@
+module IdentifySets
+  def self.sets(hand)
+    sets = []
+    unique_values = hand.cards.map(&:value).uniq
+    unique_values.each do |unique_value|
+      occurrances = hand.cards.count { |card| card.value == unique_value }
+      sets << Set.new(unique_value, occurrances)
+    end
+    sets
+  end
+end

--- a/lib/pokerscore/identify_straight.rb
+++ b/lib/pokerscore/identify_straight.rb
@@ -1,0 +1,12 @@
+WHEEL_STRAIGHT = [2,3,4,5,14]
+
+module IdentifyStraight
+  def self.straight?(hand)
+      sorted_values = hand.cards.map(&:value).sort
+      return true if sorted_values == WHEEL_STRAIGHT
+      sorted_values.each_cons(2).each do |value, next_value|
+        return false if not value == next_value - 1
+      end
+      true
+  end
+end

--- a/tests/test_hand.rb
+++ b/tests/test_hand.rb
@@ -3,17 +3,7 @@ require 'minitest/color'
 require 'tests/hand_factories.rb'
 
 class TestHand < Minitest::Test
-  def test_hand_identifies_sets
-    full_house_hand = HandFactories.full_house_hand(triplet = 5, pair = 2)
-    assert_equal full_house_hand.sets.length, 2
-  end
-
-  def test_hand_identifies_straight
-    straight_hand = HandFactories.straight_hand(high_card_value = 6)
-    assert_equal straight_hand.straight?, true
-  end
-
-  def test_hand_identifies_high_card
+  def test_hand_identifies_highest_value
     hand = HandFactories.straight_hand(high_card_value = 11)
     assert_equal hand.max_value, 11
   end

--- a/tests/test_identify_flush.rb
+++ b/tests/test_identify_flush.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+require 'minitest/color'
+require 'tests/hand_factories.rb'
+require 'lib/pokerscore/identify_flush.rb'
+
+class TestIdentifyStraight < Minitest::Test
+  def test_hand_identifies_flush
+    flush_hand = HandFactories.flush_hand(high_card_value = 6)
+    assert_equal IdentifyFlush.flush?(flush_hand), true
+  end
+end

--- a/tests/test_identify_sets.rb
+++ b/tests/test_identify_sets.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+require 'minitest/color'
+require 'tests/hand_factories.rb'
+require 'lib/pokerscore/identify_sets.rb'
+
+class TestIdentifySets < Minitest::Test
+  def test_hand_identifies_sets
+    full_house_hand = HandFactories.full_house_hand(triplet = 5, pair = 2)
+    assert_equal IdentifySets.sets(full_house_hand).length, 2
+  end
+end

--- a/tests/test_identify_straight.rb
+++ b/tests/test_identify_straight.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+require 'minitest/color'
+require 'tests/hand_factories.rb'
+require 'lib/pokerscore/identify_straight.rb'
+
+class TestIdentifyStraight < Minitest::Test
+  def test_hand_identifies_straight
+    straight_hand = HandFactories.straight_hand(high_card_value = 6)
+    assert_equal IdentifyStraight.straight?(straight_hand), true
+  end
+end


### PR DESCRIPTION
Hands should only know that they contain cards, and should only be
able to answer questions about those cards if they have nothing to do
with any game logic.

Flushes, straights, and sets are all distinct ideas, and so should be
evaluated separately.

This change is only concerned with breaking the identifiers into their
own files. Further work is required to make the hand evaluator class
follow SRP.