### PR TITLE
Create single call method for service objects

### DIFF
--- a/lib/pokerscore/identify_flush.rb
+++ b/lib/pokerscore/identify_flush.rb
@@ -4,7 +4,7 @@ class IdentifyFlush
     @hand = hand
   end
 
-  def flush?
+  def call
     @hand.cards.map(&:suit).uniq.length == 1
   end
 end

--- a/lib/pokerscore/identify_sets.rb
+++ b/lib/pokerscore/identify_sets.rb
@@ -4,7 +4,7 @@ class IdentifySets
     @hand = hand
   end
 
-  def sets
+  def call
     sets = []
     unique_values = @hand.cards.map(&:value).uniq
     unique_values.each do |unique_value|

--- a/lib/pokerscore/identify_straight.rb
+++ b/lib/pokerscore/identify_straight.rb
@@ -5,12 +5,12 @@ class IdentifyStraight
     @hand = hand
   end
 
-  def straight?
-      sorted_values = @hand.cards.map(&:value).sort
-      return true if sorted_values == WHEEL_STRAIGHT
-      sorted_values.each_cons(2).each do |value, next_value|
-        return false if not value == next_value - 1
-      end
-      true
+  def call
+    sorted_values = @hand.cards.map(&:value).sort
+    return true if sorted_values == WHEEL_STRAIGHT
+    sorted_values.each_cons(2).each do |value, next_value|
+      return false if not value == next_value - 1
+    end
+    true
   end
 end

--- a/lib/pokerscore/texas_hold_em/evaluate.rb
+++ b/lib/pokerscore/texas_hold_em/evaluate.rb
@@ -11,7 +11,7 @@ module TexasHoldEm
       @identify_hand2 = TexasHoldEm::Identify.new(hand2)
     end
 
-    def winner
+    def call
       winner = compare_hand_types
       return winner if winner != nil
       winner = compare_straights
@@ -23,8 +23,8 @@ module TexasHoldEm
     private
 
     def compare_hand_types
-      hand1_type = $hand_types[@identify_hand1.identify]
-      hand2_type = $hand_types[@identify_hand2.identify]
+      hand1_type = $hand_types[@identify_hand1.call]
+      hand2_type = $hand_types[@identify_hand2.call]
       case hand1_type <=> hand2_type
       when 1
         @hand1
@@ -69,10 +69,10 @@ module TexasHoldEm
 
     def set_values_in_rank_order(hand)
       identify_sets = IdentifySets.new(hand)
-      quads = identify_sets.sets.select(&:quad?).map(&:value).sort
-      trips = identify_sets.sets.select(&:trip?).map(&:value).sort
-      pairs = identify_sets.sets.select(&:pair?).map(&:value).sort
-      singles = identify_sets.sets.select(&:single?).map(&:value).sort
+      quads = identify_sets.call.select(&:quad?).map(&:value).sort
+      trips = identify_sets.call.select(&:trip?).map(&:value).sort
+      pairs = identify_sets.call.select(&:pair?).map(&:value).sort
+      singles = identify_sets.call.select(&:single?).map(&:value).sort
       quads + trips + pairs + singles
     end
   end

--- a/lib/pokerscore/texas_hold_em/identify.rb
+++ b/lib/pokerscore/texas_hold_em/identify.rb
@@ -12,12 +12,12 @@ module TexasHoldEm
       @identify_straight = IdentifyStraight.new(hand)
     end
 
-    def identify
-      num_pairs = @identify_sets.sets.count { |set| set.pair? }
-      num_trips = @identify_sets.sets.count { |set| set.trip? }
-      num_quads = @identify_sets.sets.count { |set| set.quad? }
-      straight = @identify_straight.straight?
-      flush = @identify_flush.flush?
+    def call
+      num_pairs = @identify_sets.call.count { |set| set.pair? }
+      num_trips = @identify_sets.call.count { |set| set.trip? }
+      num_quads = @identify_sets.call.count { |set| set.quad? }
+      straight = @identify_straight.call
+      flush = @identify_flush.call
 
       best = :high_card
       best = :pair if num_pairs == 1

--- a/tests/test_identify_flush.rb
+++ b/tests/test_identify_flush.rb
@@ -7,6 +7,6 @@ class TestIdentifyStraight < Minitest::Test
   def test_hand_identifies_flush
     flush_hand = HandFactories.flush_hand(high_card_value = 6)
     identify_flush = IdentifyFlush.new(flush_hand)
-    assert_equal identify_flush.flush?, true
+    assert_equal identify_flush.call, true
   end
 end

--- a/tests/test_identify_sets.rb
+++ b/tests/test_identify_sets.rb
@@ -7,6 +7,6 @@ class TestIdentifySets < Minitest::Test
   def test_hand_identifies_sets
     full_house_hand = HandFactories.full_house_hand(triplet = 5, pair = 2)
     identify_sets = IdentifySets.new(full_house_hand)
-    assert_equal identify_sets.sets.length, 2
+    assert_equal identify_sets.call.length, 2
   end
 end

--- a/tests/test_identify_straight.rb
+++ b/tests/test_identify_straight.rb
@@ -7,6 +7,6 @@ class TestIdentifyStraight < Minitest::Test
   def test_hand_identifies_straight
     straight_hand = HandFactories.straight_hand(high_card_value = 6)
     identify_straight = IdentifyStraight.new(straight_hand)
-    assert_equal identify_straight.straight?, true
+    assert_equal identify_straight.call, true
   end
 end

--- a/tests/texas_hold_em/test_evaluate.rb
+++ b/tests/texas_hold_em/test_evaluate.rb
@@ -8,27 +8,27 @@ class TestHand < Minitest::Test
     flush = HandFactories.flush_hand(high_card_value = 10)
     straight = HandFactories.straight_hand(high_card_value = 7)
     evaluate = TexasHoldEm::Evaluate.new(flush, straight)
-    assert_equal evaluate.winner, flush
+    assert_equal evaluate.call, flush
   end
 
   def test_hand_evaluator_accurately_finds_tie_and_returns_nil
     trips1 = HandFactories.hand([2,2,2,5,6])
     trips2 = HandFactories.hand([2,2,2,5,6])
     evaluate = TexasHoldEm::Evaluate.new(trips1, trips2)
-    assert_nil evaluate.winner
+    assert_nil evaluate.call
   end
 
   def test_hand_evaluator_accurately_finds_winner_wheel_straight_vs_straight
     wheel_straight = HandFactories.hand([2,3,4,5,14])
     straight = HandFactories.straight_hand(high_card_value = 6)
     evaluate = TexasHoldEm::Evaluate.new(wheel_straight, straight)
-    assert_equal evaluate.winner, straight
+    assert_equal evaluate.call, straight
   end
 
   def test_hand_evaluator_accurately_finds_winner_sets_vs_sets
     two_pair1 = HandFactories.two_pair_hand(pair_value1 = 5, pair_value2 = 3)
     two_pair2 = HandFactories.two_pair_hand(pair_value1 = 5, pair_value2 = 2)
     evaluate = TexasHoldEm::Evaluate.new(two_pair1, two_pair2)
-    assert_equal evaluate.winner, two_pair1
+    assert_equal evaluate.call, two_pair1
   end
 end

--- a/tests/texas_hold_em/test_identify.rb
+++ b/tests/texas_hold_em/test_identify.rb
@@ -7,61 +7,61 @@ class TestHand < Minitest::Test
 
   def test_hand_evaluator_identifies_pair
     pair_hand = HandFactories.pair_hand(pair_value = 10)
-    identify_pair_hand = TexasHoldEm::Identify.new(pair_hand)
-    assert_equal identify_pair_hand.identify, :pair
+    identify = TexasHoldEm::Identify.new(pair_hand)
+    assert_equal identify.call, :pair
   end
 
   def test_hand_evaluator_identifies_two_pair
     two_pair_hand = HandFactories.two_pair_hand(pair_value1 = 3, pair_value2 = 5)
-    identify_two_pair_hand = TexasHoldEm::Identify.new(two_pair_hand)
-    assert_equal identify_two_pair_hand.identify, :two_pair
+    identify = TexasHoldEm::Identify.new(two_pair_hand)
+    assert_equal identify.call, :two_pair
   end
 
   def test_hand_evaluator_identifies_trips
     trips_hand = HandFactories.triplet_hand(triplet_value = 6)
-    identify_trips_hand = TexasHoldEm::Identify.new(trips_hand)
-    assert_equal identify_trips_hand.identify, :three_of_a_kind
+    identify = TexasHoldEm::Identify.new(trips_hand)
+    assert_equal identify.call, :three_of_a_kind
   end
 
   def test_hand_evaluator_identifies_full_house
     full_house_hand = HandFactories.full_house_hand(triplet = 5, pair = 2)
-    identify_full_house_hand = TexasHoldEm::Identify.new(full_house_hand)
-    assert_equal identify_full_house_hand.identify, :full_house
+    identify = TexasHoldEm::Identify.new(full_house_hand)
+    assert_equal identify.call, :full_house
   end
 
   def test_hand_evaluator_identifies_quad
     quad_hand = HandFactories.four_of_a_kind_hand(four_of_a_kind_value = 6)
-    identify_quad_hand = TexasHoldEm::Identify.new(quad_hand)
-    assert_equal identify_quad_hand.identify, :four_of_a_kind
+    identify = TexasHoldEm::Identify.new(quad_hand)
+    assert_equal identify.call, :four_of_a_kind
   end
 
   def test_hand_evaluator_identifies_royal_flush
     royal_flush_hand = HandFactories.royal_flush_hand
-    identify_royal_flush_hand = TexasHoldEm::Identify.new(royal_flush_hand)
-    assert_equal identify_royal_flush_hand.identify, :royal_flush
+    identify = TexasHoldEm::Identify.new(royal_flush_hand)
+    assert_equal identify.call, :royal_flush
   end
 
   def test_hand_evaluator_identifies_straight_flush
     straight_flush_hand = HandFactories.straight_flush_hand(high_card_value = 10)
-    identify_straight_flush_hand = TexasHoldEm::Identify.new(straight_flush_hand)
-    assert_equal identify_straight_flush_hand.identify, :straight_flush
+    identify = TexasHoldEm::Identify.new(straight_flush_hand)
+    assert_equal identify.call, :straight_flush
   end
 
   def test_hand_evaluator_identifies_straight
     straight_hand = HandFactories.straight_hand(high_card_value = 6)
-    identify_straight_hand = TexasHoldEm::Identify.new(straight_hand)
-    assert_equal identify_straight_hand.identify, :straight
+    identify = TexasHoldEm::Identify.new(straight_hand)
+    assert_equal identify.call, :straight
   end
 
   def test_hand_evaluator_identifies_straight_from_wheel_straight
     wheel_straight_hand = HandFactories.hand([2,3,4,5,14])
-    identify_wheel_straight_hand = TexasHoldEm::Identify.new(wheel_straight_hand)
-    assert_equal identify_wheel_straight_hand.identify, :straight
+    identify = TexasHoldEm::Identify.new(wheel_straight_hand)
+    assert_equal identify.call, :straight
   end
 
   def test_hand_evaluator_identifies_flush
     flush_hand = HandFactories.flush_hand(high_card = 7)
-    identify_flush_hand = TexasHoldEm::Identify.new(flush_hand)
-    assert_equal identify_flush_hand.identify, :flush
+    identify = TexasHoldEm::Identify.new(flush_hand)
+    assert_equal identify.call, :flush
   end
 end


### PR DESCRIPTION
Each service object should perform only one task and contain only one
public method apart from initialize(). This method should perform a
task in line with the name of the class. Since the name of the class
describes the task that is being performed, we can change the name of
the public method to "call". This makes calls to the service object
shorter and easier to scan.