### PR TITLE
Call service objects after instantiation

### DIFF
--- a/lib/pokerscore/texas_hold_em/evaluate.rb
+++ b/lib/pokerscore/texas_hold_em/evaluate.rb
@@ -7,8 +7,8 @@ module TexasHoldEm
     def initialize(hand1, hand2)
       @hand1 = hand1
       @hand2 = hand2
-      @identify_hand1 = TexasHoldEm::Identify.new(hand1)
-      @identify_hand2 = TexasHoldEm::Identify.new(hand2)
+      @hand1_type = TexasHoldEm::Identify.new(hand1).call
+      @hand2_type = TexasHoldEm::Identify.new(hand2).call
     end
 
     def call
@@ -23,8 +23,8 @@ module TexasHoldEm
     private
 
     def compare_hand_types
-      hand1_type = $hand_types[@identify_hand1.call]
-      hand2_type = $hand_types[@identify_hand2.call]
+      hand1_type = $hand_types[@hand1_type]
+      hand2_type = $hand_types[@hand2_type]
       case hand1_type <=> hand2_type
       when 1
         @hand1
@@ -68,11 +68,11 @@ module TexasHoldEm
     end
 
     def set_values_in_rank_order(hand)
-      identify_sets = IdentifySets.new(hand)
-      quads = identify_sets.call.select(&:quad?).map(&:value).sort
-      trips = identify_sets.call.select(&:trip?).map(&:value).sort
-      pairs = identify_sets.call.select(&:pair?).map(&:value).sort
-      singles = identify_sets.call.select(&:single?).map(&:value).sort
+      sets = IdentifySets.new(hand).call
+      quads = sets.select(&:quad?).map(&:value).sort
+      trips = sets.select(&:trip?).map(&:value).sort
+      pairs = sets.select(&:pair?).map(&:value).sort
+      singles = sets.select(&:single?).map(&:value).sort
       quads + trips + pairs + singles
     end
   end

--- a/lib/pokerscore/texas_hold_em/identify.rb
+++ b/lib/pokerscore/texas_hold_em/identify.rb
@@ -7,17 +7,17 @@ module TexasHoldEm
 
     def initialize(hand)
       @hand = hand
-      @identify_sets = IdentifySets.new(hand)
-      @identify_flush = IdentifyFlush.new(hand)
-      @identify_straight = IdentifyStraight.new(hand)
+      @sets = IdentifySets.new(hand).call
+      @is_flush = IdentifyFlush.new(hand).call
+      @is_straight = IdentifyStraight.new(hand).call
     end
 
     def call
-      num_pairs = @identify_sets.call.count { |set| set.pair? }
-      num_trips = @identify_sets.call.count { |set| set.trip? }
-      num_quads = @identify_sets.call.count { |set| set.quad? }
-      straight = @identify_straight.call
-      flush = @identify_flush.call
+      num_pairs = @sets.count { |set| set.pair? }
+      num_trips = @sets.count { |set| set.trip? }
+      num_quads = @sets.count { |set| set.quad? }
+      straight = @is_straight
+      flush = @is_flush
 
       best = :high_card
       best = :pair if num_pairs == 1

--- a/tests/test_identify_flush.rb
+++ b/tests/test_identify_flush.rb
@@ -6,7 +6,6 @@ require 'lib/pokerscore/identify_flush.rb'
 class TestIdentifyStraight < Minitest::Test
   def test_hand_identifies_flush
     flush_hand = HandFactories.flush_hand(high_card_value = 6)
-    identify_flush = IdentifyFlush.new(flush_hand)
-    assert_equal identify_flush.call, true
+    assert_equal IdentifyFlush.new(flush_hand).call, true
   end
 end

--- a/tests/test_identify_sets.rb
+++ b/tests/test_identify_sets.rb
@@ -6,7 +6,7 @@ require 'lib/pokerscore/identify_sets.rb'
 class TestIdentifySets < Minitest::Test
   def test_hand_identifies_sets
     full_house_hand = HandFactories.full_house_hand(triplet = 5, pair = 2)
-    identify_sets = IdentifySets.new(full_house_hand)
-    assert_equal identify_sets.call.length, 2
+    sets = IdentifySets.new(full_house_hand).call
+    assert_equal sets.length, 2
   end
 end

--- a/tests/test_identify_straight.rb
+++ b/tests/test_identify_straight.rb
@@ -6,7 +6,6 @@ require 'lib/pokerscore/identify_straight.rb'
 class TestIdentifyStraight < Minitest::Test
   def test_hand_identifies_straight
     straight_hand = HandFactories.straight_hand(high_card_value = 6)
-    identify_straight = IdentifyStraight.new(straight_hand)
-    assert_equal identify_straight.call, true
+    assert_equal IdentifyStraight.new(straight_hand).call, true
   end
 end


### PR DESCRIPTION
Since service objects only perform one task, it often doesn't make
sense to store a reference to the object instead of the result of its
task. By calling the object immediately after instantiating it, we
can use a descriptive variable to name its result.