### PR TITLE
Initialize Identify object without hand

### DIFF
--- a/lib/pokerscore/texas_hold_em/evaluate.rb
+++ b/lib/pokerscore/texas_hold_em/evaluate.rb
@@ -10,8 +10,6 @@ module TexasHoldEm
     def initialize(hand1, hand2)
       @hand1 = hand1
       @hand2 = hand2
-      @hand1_type = TexasHoldEm::Identify.new(hand1).call
-      @hand2_type = TexasHoldEm::Identify.new(hand2).call
     end
 
     def call
@@ -28,8 +26,9 @@ module TexasHoldEm
     private
 
     def compare_hand_types
-      hand1_type = $hand_types[@hand1_type]
-      hand2_type = $hand_types[@hand2_type]
+      identify = TexasHoldEm::Identify.new
+      hand1_type = $hand_types[identify.call(@hand1)]
+      hand2_type = $hand_types[identify.call(@hand2)]
       case hand1_type <=> hand2_type
       when 1
         @hand1

--- a/lib/pokerscore/texas_hold_em/identify.rb
+++ b/lib/pokerscore/texas_hold_em/identify.rb
@@ -7,31 +7,24 @@ require 'lib/pokerscore/quad_search'
 module TexasHoldEm
   class Identify
 
-    def initialize(hand)
-      @hand = hand
-      @pairs = PokerScore::PairSearch.new.call(@hand)
-      @trips = PokerScore::TripSearch.new.call(@hand)
-      @quads = PokerScore::QuadSearch.new.call(@hand)
-      @has_flush = IdentifyFlush.new(hand).call
-      @has_straight = IdentifyStraight.new(hand).call
-    end
-
-    def call
-      num_pairs = @pairs.size
-      num_trips = @trips.size
-      num_quads = @quads.size
+    def call(hand)
+      num_pairs = PokerScore::PairSearch.new.call(hand).size
+      num_trips = PokerScore::TripSearch.new.call(hand).size
+      num_quads = PokerScore::QuadSearch.new.call(hand).size
+      has_flush = IdentifyFlush.new(hand).call
+      has_straight = IdentifyStraight.new(hand).call
 
       best = :high_card
       best = :pair if num_pairs == 1
       best = :two_pair if num_pairs == 2
       best = :three_of_a_kind if num_trips == 1
-      best = :straight if @has_straight and !@has_flush
-      best = :flush if @has_flush
+      best = :straight if has_straight and !has_flush
+      best = :flush if has_flush
       best = :full_house if num_trips == 1 and num_pairs == 1
       best = :four_of_a_kind if num_quads == 1
-      if @has_flush
-        best = :straight_flush if @has_straight
-        best = :royal_flush if @has_straight and @hand.max_value == 14
+      if has_flush
+        best = :straight_flush if has_straight
+        best = :royal_flush if has_straight and hand.max_value == 14
       end
       best
     end

--- a/tests/texas_hold_em/test_identify.rb
+++ b/tests/texas_hold_em/test_identify.rb
@@ -4,64 +4,58 @@ require 'tests/hand_factories.rb'
 require 'lib/pokerscore/texas_hold_em/identify.rb'
 
 class TestIdentify < Minitest::Test
+  extend Minitest::Spec::DSL
+
+  let(:identify) { TexasHoldEm::Identify.new }
+  subject { identify.call(hand) }
 
   def test_identify_finds_pair
-    pair_hand = HandFactories.pair_hand(pair_value = 10)
-    identify = TexasHoldEm::Identify.new(pair_hand)
-    assert_equal identify.call, :pair
+    hand = HandFactories.pair_hand(pair_value = 10)
+    assert_equal identify.call(hand), :pair
   end
 
   def test_identify_finds_two_pair
-    two_pair_hand = HandFactories.two_pair_hand(pair_value1 = 3, pair_value2 = 5)
-    identify = TexasHoldEm::Identify.new(two_pair_hand)
-    assert_equal identify.call, :two_pair
+    hand = HandFactories.two_pair_hand(pair_value1 = 3, pair_value2 = 5)
+    assert_equal identify.call(hand), :two_pair
   end
 
   def test_identify_finds_trips
-    trips_hand = HandFactories.triplet_hand(triplet_value = 6)
-    identify = TexasHoldEm::Identify.new(trips_hand)
-    assert_equal identify.call, :three_of_a_kind
+    hand = HandFactories.triplet_hand(triplet_value = 6)
+    assert_equal identify.call(hand), :three_of_a_kind
   end
 
   def test_identify_finds_full_house
-    full_house_hand = HandFactories.full_house_hand(triplet = 5, pair = 2)
-    identify = TexasHoldEm::Identify.new(full_house_hand)
-    assert_equal identify.call, :full_house
+    hand = HandFactories.full_house_hand(triplet = 5, pair = 2)
+    assert_equal identify.call(hand), :full_house
   end
 
   def test_identify_finds_quad
-    quad_hand = HandFactories.four_of_a_kind_hand(four_of_a_kind_value = 6)
-    identify = TexasHoldEm::Identify.new(quad_hand)
-    assert_equal identify.call, :four_of_a_kind
+    hand = HandFactories.four_of_a_kind_hand(four_of_a_kind_value = 6)
+    assert_equal identify.call(hand), :four_of_a_kind
   end
 
   def test_identify_finds_royal_flush
-    royal_flush_hand = HandFactories.royal_flush_hand
-    identify = TexasHoldEm::Identify.new(royal_flush_hand)
-    assert_equal identify.call, :royal_flush
+    hand = HandFactories.royal_flush_hand
+    assert_equal identify.call(hand), :royal_flush
   end
 
   def test_identify_finds_straight_flush
-    straight_flush_hand = HandFactories.straight_flush_hand(high_card_value = 10)
-    identify = TexasHoldEm::Identify.new(straight_flush_hand)
-    assert_equal identify.call, :straight_flush
+    hand = HandFactories.straight_flush_hand(high_card_value = 10)
+    assert_equal identify.call(hand), :straight_flush
   end
 
   def test_identify_finds_straight
-    straight_hand = HandFactories.straight_hand(high_card_value = 6)
-    identify = TexasHoldEm::Identify.new(straight_hand)
-    assert_equal identify.call, :straight
+    hand = HandFactories.straight_hand(high_card_value = 6)
+    assert_equal identify.call(hand), :straight
   end
 
   def test_identify_finds_straight_from_wheel_straight
-    wheel_straight_hand = HandFactories.hand([2,3,4,5,14])
-    identify = TexasHoldEm::Identify.new(wheel_straight_hand)
-    assert_equal identify.call, :straight
+    hand = HandFactories.hand([2,3,4,5,14])
+    assert_equal identify.call(hand), :straight
   end
 
   def test_identify_finds_flush
-    flush_hand = HandFactories.flush_hand(high_card = 7)
-    identify = TexasHoldEm::Identify.new(flush_hand)
-    assert_equal identify.call, :flush
+    hand = HandFactories.flush_hand(high_card = 7)
+    assert_equal identify.call(hand), :flush
   end
 end


### PR DESCRIPTION
By passing Identify a hand when calling, rather than when initializing,
we can create a single Identify object to use on multiple hands.