### PR TITLE
Remove hand type comparison from Evaluate

### DIFF
--- a/lib/pokerscore/compare_hand_types.rb
+++ b/lib/pokerscore/compare_hand_types.rb
@@ -1,0 +1,18 @@
+require 'const/hand_constants'
+require 'lib/pokerscore/texas_hold_em/identify'
+
+class CompareHandTypes
+  def call(hand1, hand2)
+    identify = TexasHoldEm::Identify.new
+    hand1_type = $hand_types[identify.call(hand1)]
+    hand2_type = $hand_types[identify.call(hand2)]
+    case hand1_type <=> hand2_type
+    when 1
+      hand1
+    when 0
+      nil
+    when -1
+      hand2
+    end
+  end
+end

--- a/lib/pokerscore/texas_hold_em/evaluate.rb
+++ b/lib/pokerscore/texas_hold_em/evaluate.rb
@@ -3,6 +3,7 @@ require 'const/hand_constants.rb'
 require 'lib/pokerscore/pair_search'
 require 'lib/pokerscore/trip_search'
 require 'lib/pokerscore/quad_search'
+require 'lib/pokerscore/compare_hand_types.rb'
 
 module TexasHoldEm
   class Evaluate
@@ -13,7 +14,7 @@ module TexasHoldEm
     end
 
     def call
-      winner = compare_hand_types
+      winner = CompareHandTypes.new.call(@hand1, @hand2)
       return winner if winner != nil
       winner = compare_straights
       return winner if winner != nil
@@ -24,20 +25,6 @@ module TexasHoldEm
     end
 
     private
-
-    def compare_hand_types
-      identify = TexasHoldEm::Identify.new
-      hand1_type = $hand_types[identify.call(@hand1)]
-      hand2_type = $hand_types[identify.call(@hand2)]
-      case hand1_type <=> hand2_type
-      when 1
-        @hand1
-      when 0
-        nil
-      when -1
-        @hand2
-      end
-    end
 
     def compare_sets
       hand1_set_values = set_values_in_rank_order(@hand1)

--- a/tests/texas_hold_em/test_compare_hand_types.rb
+++ b/tests/texas_hold_em/test_compare_hand_types.rb
@@ -1,0 +1,21 @@
+require 'minitest/autorun'
+require 'minitest/color'
+require 'lib/pokerscore/compare_hand_types'
+require 'tests/hand_factories'
+
+class TestCompareHandTypes < MiniTest::Test
+  extend Minitest::Spec::DSL
+
+  let(:compare) { CompareHandTypes.new }
+
+  def test_compare_hand_types_finds_winner
+    winner = HandFactories::full_house_hand(4,2)
+    loser = HandFactories::high_card_hand(9)
+    assert_equal compare.call(winner, loser), winner
+  end
+
+  def test_compare_hand_types_finds_tie
+    hand = HandFactories::high_card_hand(12)
+    assert_nil compare.call(hand, hand)
+  end
+end


### PR DESCRIPTION
Comparing hands is a different responsibility than evaluating hands,
and so no comparison logic should be included in the Evaluate class.